### PR TITLE
Add performance counter for the Python bindings

### DIFF
--- a/rdtsc.h
+++ b/rdtsc.h
@@ -27,7 +27,7 @@ Issue Date: 20/12/2007
     {
         unsigned int cyl, cyh;
         /* The cpuid instruction clobbers EBX, EDX and ECX */
-        __asm__ __volatile__("cpuid; rdtsc":"=a"(cyl),"=d"(cyh)::"ebx","ecx");
+        __asm__ __volatile__("movl $0, %%eax; cpuid; rdtsc":"=a"(cyl),"=d"(cyh)::"ebx","ecx");
         return ((unsigned long long)cyh << 32) | cyl;
     }
 


### PR DESCRIPTION
This pull request fixes the read_tsc function on x86 Linux.  It also makes it possible to return CPU cycle counts from the AES encrypt and decrypt functions to Python.  The example script, demo.py, has been updated to show these values.
