### PR TITLE
Support for 32-bit x86 and Clang

### DIFF
--- a/aes.h
+++ b/aes.h
@@ -78,16 +78,24 @@ typedef union
 
 #ifdef _WIN64
 __declspec(align(16))
-#endif 
+#endif
+#if defined(__GNUC__) || defined(__clang__) 
+typedef struct __attribute__((aligned(16)))
+#else
 typedef struct
+#endif
 {   uint32_t ks[KS_LENGTH];
     aes_inf inf;
 } aes_encrypt_ctx;
 
 #ifdef _WIN64
 __declspec(align(16))
-#endif 
+#endif
+#if defined(__GNUC__) || defined(__clang__) 
+typedef struct __attribute__((aligned(16)))
+#else
 typedef struct
+#endif
 {   uint32_t ks[KS_LENGTH];
     aes_inf inf;
 } aes_decrypt_ctx;

--- a/aes_ni.c
+++ b/aes_ni.c
@@ -39,7 +39,7 @@ INLINE int has_aes_ni()
 	return test;
 }
 
-#elif defined( __GNUC__ )
+#elif defined( __GNUC__ ) || defined(__clang__)
 
 #include <cpuid.h>
 #pragma GCC target ("ssse3")
@@ -63,7 +63,7 @@ INLINE int has_aes_ni()
 }
 
 #else
-#error AES New Instructions require Microsoft, Intel or GNU C
+#error AES New Instructions require Microsoft, Intel, GNU C, or CLANG
 #endif
 
 INLINE __m128i aes_128_assist(__m128i t1, __m128i t2)
@@ -520,7 +520,7 @@ void AES_CTR_encrypt(const unsigned char *in,
 	else length /= 16;
 	ONE = _mm_set_epi32(0, 1, 0, 0);
 	BSWAP_EPI64 = _mm_setr_epi8(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8);
-	ctr_block = _mm_insert_epi64(ctr_block, *(long long*)ivec, 1);
+	ctr_block = _mm_set_epi64(*(__m64*)ivec, (__m64)ctr_block[0]);
 	ctr_block = _mm_insert_epi32(ctr_block, *(long*)nonce, 1);
 	ctr_block = _mm_srli_si128(ctr_block, 4);
 	ctr_block = _mm_shuffle_epi8(ctr_block, BSWAP_EPI64);

--- a/aesopt.h
+++ b/aesopt.h
@@ -169,8 +169,9 @@ Issue Date: 20/12/2007
 #  define VIA_ACE_POSSIBLE
 #endif
 
-#if defined( _WIN64 ) && defined( _MSC_VER ) \
- || defined( __GNUC__ ) && defined( __x86_64__ )
+#if (defined( _WIN64 ) && defined( _MSC_VER )) \
+ || (defined( __GNUC__ ) && defined( __x86_64__ )) \
+ && !(defined( INTEL_AES_POSSIBLE ))
 #  define INTEL_AES_POSSIBLE
 #endif
 


### PR DESCRIPTION
Added support for Clang (OSX)
Added struct alignment directives: __attribute__(aligned(16)) -- gcc/clang support
Replaced _mm_insert_epi64 with _mm_set_epi64 -- _mm_insert_epi64 is not defined for 32-bit x86 on posix