### PR TITLE
Corrected some issues affecting GNU GCC and Clang/LLVM

### DIFF
--- a/aes.h
+++ b/aes.h
@@ -76,26 +76,20 @@ typedef union
 #  pragma warning( disable : 4324 )
 #endif
 
-#ifdef _WIN64
-__declspec(align(16))
-#endif
-#if defined(__GNUC__) || defined(__clang__) 
-typedef struct __attribute__((aligned(16)))
+#if defined(_MSC_VER) && defined(_WIN64)
+#define ALIGNED_(x) __declspec(align(x))
+#elif defined(__GNUC__) && defined(__x86_64__)
+#define ALIGNED_(x) __attribute__ ((aligned(x)))
 #else
-typedef struct
+#define ALIGNED_(x)
 #endif
+
+typedef struct ALIGNED_(16)
 {   uint32_t ks[KS_LENGTH];
     aes_inf inf;
 } aes_encrypt_ctx;
 
-#ifdef _WIN64
-__declspec(align(16))
-#endif
-#if defined(__GNUC__) || defined(__clang__) 
-typedef struct __attribute__((aligned(16)))
-#else
-typedef struct
-#endif
+typedef struct ALIGNED_(16)
 {   uint32_t ks[KS_LENGTH];
     aes_inf inf;
 } aes_decrypt_ctx;

--- a/aes_ni.c
+++ b/aes_ni.c
@@ -39,7 +39,7 @@ INLINE int has_aes_ni()
 	return test;
 }
 
-#elif defined( __GNUC__ ) || defined(__clang__)
+#elif defined( __GNUC__ )
 
 #include <cpuid.h>
 #pragma GCC target ("ssse3")
@@ -556,7 +556,7 @@ AES_RETURN AES_CTR_encrypt(const unsigned char *in,
     else length /= 16;
     ONE = _mm_set_epi32(0, 1, 0, 0);
     BSWAP_EPI64 = _mm_setr_epi8(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8);
-#ifdef _WIN64
+#ifdef _MSC_VER
     ctr_block = _mm_insert_epi64(ctr_block, *(long long*)ivec, 1);
 #else
     ctr_block = _mm_set_epi64(*(__m64*)ivec, *(__m64*)&ctr_block);
@@ -654,7 +654,7 @@ void AES_CTR_encrypt(const unsigned char *in,
 	else length /= 16;
 	ONE = _mm_set_epi32(0, 1, 0, 0);
 	BSWAP_EPI64 = _mm_setr_epi8(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8);
-#ifdef _WIN64
+#ifdef _MSC_VER
 	ctr_block = _mm_insert_epi64(ctr_block, *(long long*)ivec, 1);
 #else
 	ctr_block = _mm_set_epi64(*(__m64*)ivec, *(__m64*)&ctr_block);

--- a/aes_via_ace.h
+++ b/aes_via_ace.h
@@ -350,7 +350,10 @@ INLINE int has_cpuid(void)
 
 INLINE int is_via_cpu(void)
 {   int val;
+    asm("pushl %eax\n\t");
     asm("pushl %ebx\n\t");
+    asm("pushl %ecx\n\t");
+    asm("pushl %edx\n\t");
     asm("xorl %eax,%eax\n\t");
     asm("cpuid\n\t");
     asm("xorl %eax,%eax\n\t");
@@ -361,7 +364,10 @@ INLINE int is_via_cpu(void)
     asm("subl $0x736c7561,%ecx\n\t");
     asm("orl  %ecx,%eax\n\t");
     asm("movl %%eax,%0\n\t" : "=m" (val));
+    asm("popl %edx\n\t");
+    asm("popl %ecx\n\t");
     asm("popl %ebx\n\t");
+    asm("popl %eax\n\t");
     val = (val ? 0 : 1);
     via_flags = (val | NEH_CPU_READ);
     return val;


### PR DESCRIPTION
**aes.h**: Created a cross-platform alignment macro that works with GNU GCC, Clang/LLVM, and MS Visual Studio. GCC on Windows has built-in defines for both _WIN64_ and for _declspec()_, which caused the code emitted to the compiler to contain redundant (and incorrect) alignment attributes for the _aes_encrypt_ctx_ and _aes_decrypt_ctx_ structs. The new _ALIGNED_()_ macro solves these issues.

**aes_ni.c**: Corrected unnecessary use of _clang_ define; updated check for _WIN64_ to instead check for _MSC_VER_. It turns out that Clang has a built-in define for _GNUC_, so checking for _GNUC_ || _clang_ is redundant. Also, since GCC on Windows defines _WIN64_ (as mentioned above), we should use _MSC_VER_ to differentiate between compilers on windows. (See aes_ni.c:559, 657) 

**aes_via_ace.h**: Added additional protection for preserving registers (using _pushl_ and _popl_) in the _is_via_cpu()_ inline method to prevent a crash on OSX (compiled for 32-bit).

These changes have been tested on the following platforms:
- Windows 10 64-bit, MS Visual Studio 2013 (x64 and win32)
- Windows 10 64-bit, GNU GCC (m64 and m32)
- Ubuntu 14.04 64-bit, GNU GCC (m64 and m32)
- OSX Yosemite 64-bit, Clang/LLVM (m64 and m32)
