### PR TITLE
Add macro to optionally not export the init function.

### DIFF
--- a/python_binding/aesmodule.c
+++ b/python_binding/aesmodule.c
@@ -512,6 +512,18 @@ static PyMethodDef aes_methods[] =
 #define PyMODINIT_FUNC void
 #endif
 
+#ifdef EXPORT_INITFUNC
+/* we must redefine PyMODINIT_FUNC to avoid
+ * exporting the init function. */
+#undef PyMODINIT_FUNC
+#if PY_MAJOR_VERSION >= 3
+/* in python 3.x module init returns PyObject *. */
+#define PyMODINIT_FUNC PyObject *
+#else
+#define PyMODINIT_FUNC void
+#endif
+#endif
+
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef =
 {


### PR DESCRIPTION
From issue https://github.com/BrianGladman/aes/issues/30 Initially I was looking into how to compile the enxtension itself into an embedded python interpreter, however after source diving and looking in setup.py I found the module init function is still exported and trying to define Py_BUILD_CORE results in a compile error because it cant find 2 specific symbols on linkage. As such this macro to optionally not export this init function is needed in cases like including it in an embedded python interpreter that the Py_BUILD_CORE one wont work on at all. Such case was also in cython before I fixed that with a macro similar to one here.