### PR TITLE
Fixed warnings on clang in Windows.

### DIFF
--- a/aescrypt.c
+++ b/aescrypt.c
@@ -55,7 +55,7 @@ extern "C"
    so we need to control this with the following VC++ pragmas
 */
 
-#if defined( _MSC_VER ) && !defined( _WIN64 )
+#if defined( _MSC_VER ) && !defined( _WIN64 ) && !defined( __clang__ )
 #pragma optimize( "s", on )
 #endif
 
@@ -172,7 +172,7 @@ AES_RETURN aes_xi(encrypt)(const unsigned char *in, unsigned char *out, const ae
    so we need to control this with the following VC++ pragmas
 */
 
-#if defined( _MSC_VER ) && !defined( _WIN64 )
+#if defined( _MSC_VER ) && !defined( _WIN64 ) && !defined( __clang__ )
 #pragma optimize( "t", on )
 #endif
 

--- a/brg_endian.h
+++ b/brg_endian.h
@@ -24,6 +24,13 @@ Issue Date: 20/12/2007
 #define IS_BIG_ENDIAN      4321 /* byte 0 is most significant (mc68k) */
 #define IS_LITTLE_ENDIAN   1234 /* byte 0 is least significant (i386) */
 
+/* required undefine when using clang with MSVC to
+ * avoid including endian.h and byteswap.h which
+ * are both not existing on Windows. */
+#if defined( _MSC_VER) && defined( __clang__ )
+#  undef __GNUC__
+#endif
+
 /* Include files where endian defines and byteswap functions may reside */
 #if defined( __sun )
 #  include <sys/isa_defs.h>


### PR DESCRIPTION
On clang in Windows clang warns on these pragmas like so:

```
1>aescrypt.c
1>..\externals\aes\aescrypt.c(59,9): warning : unknown pragma ignored [-Wunknown-pragmas]
1>#pragma optimize( "s", on )
1>        ^
1>..\externals\aes\aescrypt.c(176,9): warning : unknown pragma ignored [-Wunknown-pragmas]
1>#pragma optimize( "t", on )
1>        ^
1>'aes_decrypt': Intrinsic not yet implemented:
1>  %10 = call i32 @llvm.objectsize.i32.p0i8(i8* %9, i1 false), !nosanitize !10
1>..\externals\aes\aescrypt.c : fatal error C1001: An internal error has occurred in the compiler.
1>(compiler file 'llvm-bridge.cpp', line 5820)
```

This fixes those by checking if  ``__clang__`` is not defined. Also on brg_endian.h it needs to check if ``_MSC_VER`` and ``__clang__`` are defined to undefine ``__GNUC__`` otherwise that will try to include 2 headers that does not exist on Windows.