### PR TITLE
Add a couple of workarounds in brg_endian

### DIFF
--- a/brg_endian.h
+++ b/brg_endian.h
@@ -36,7 +36,8 @@ Issue Date: 20/12/2007
 #elif defined( __FreeBSD__ ) || defined( __OpenBSD__ ) || defined( __NetBSD__ )
 #  include <sys/endian.h>
 #elif defined( BSD ) && ( BSD >= 199103 ) || defined( __APPLE__ ) || \
-      defined( __CYGWIN32__ ) || defined( __DJGPP__ ) || defined( __osf__ )
+      defined( __CYGWIN32__ ) || defined( __DJGPP__ ) || defined( __osf__ ) || \
+      defined(HAVE_MACHINE_ENDIAN)
 #  include <machine/endian.h>
 #elif defined( __linux__ ) || defined( __GNUC__ ) || defined( __GNU_LIBRARY__ )
 #  if !defined( __MINGW32__ ) && !defined( _AIX )
@@ -85,6 +86,13 @@ Issue Date: 20/12/2007
 #  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
 #elif defined( __LITTLE_ENDIAN )
 #  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if !defined(__BIG_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
+#  define __BIG_ENDIAN__ __ORDER_BIG_ENDIAN__
+#endif
+#if !defined(__LITTLE_ENDIAN__) && defined(__ORDER_LITTLE_ENDIAN__)
+#  define __LITTLE_ENDIAN__ __ORDER_LITTLE_ENDIAN__
 #endif
 
 #if defined( __BIG_ENDIAN__ ) && defined( __LITTLE_ENDIAN__ )

--- a/brg_endian.h
+++ b/brg_endian.h
@@ -88,13 +88,6 @@ Issue Date: 20/12/2007
 #  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
 #endif
 
-#if !defined(__BIG_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
-#  define __BIG_ENDIAN__ __ORDER_BIG_ENDIAN__
-#endif
-#if !defined(__LITTLE_ENDIAN__) && defined(__ORDER_LITTLE_ENDIAN__)
-#  define __LITTLE_ENDIAN__ __ORDER_LITTLE_ENDIAN__
-#endif
-
 #if defined( __BIG_ENDIAN__ ) && defined( __LITTLE_ENDIAN__ )
 #  if defined( __BYTE_ORDER__ ) && __BYTE_ORDER__ == __BIG_ENDIAN__
 #    define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
@@ -105,6 +98,16 @@ Issue Date: 20/12/2007
 #  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
 #elif defined( __LITTLE_ENDIAN__ )
 #  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if !defined(PLATFORM_BYTE_ORDER) && defined( __GNUC__ ) && \
+    defined( __BYTE_ORDER__ ) && defined(__ORDER_BIG_ENDIAN__) && \
+    defined(__ORDER_LITTLE_ENDIAN__)
+#  if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#    define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#  elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#    define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#  endif
 #endif
 
 /*  if the platform byte order could not be determined, then try to */


### PR DESCRIPTION
While using the arm embedded toolchain from here:

https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads

I noticed that ```brg_endian.h``` fails to work as expected.  I eventually traced it back to two issues:

1) Looking through the list of preprocessor macros, I noticed that recent versions of GCC define e.g. ```__ORDER_BIG_ENDIAN__``` instead of ```__BIG_ENDIAN__```:

```
michael@requiem:~/git/aes$ arm-none-eabi-gcc -dM -E - < /dev/null | grep ENDIAN
#define __ORDER_LITTLE_ENDIAN__ 1234
#define __FLOAT_WORD_ORDER__ __ORDER_LITTLE_ENDIAN__
#define __ORDER_PDP_ENDIAN__ 3412
#define __ORDER_BIG_ENDIAN__ 4321
#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
michael@requiem:~/git/aes$
```

Not being sure whether this block is intended for use by GCC or Visual Studio, I've opted to take the path of least change and just define the expected macros.

2) At least for the ARM toolchain linked above (perhaps because this is for bare metal?), the header endian.h isn't in the typical path for gcc.  I looked through the preprocessor macros for anything which might help automatically identify this situation but didn't see anything obvious.  Instead I've added a way to force this behavior on demand (as a compile-time option).