### PR TITLE
Minor fixes for ancillary tool (test suite) compilation on Linux/GCC

### DIFF
--- a/aes_avs.c
+++ b/aes_avs.c
@@ -42,7 +42,7 @@ char *klen_str[] = { "128",  "192",  "256" };
 typedef enum { L_bad = -1, L_count = 0, L_key, L_iv, L_plaintext, L_ciphertext } line_type;
 char *hdr_str[] = { "COUNT = ", "KEY = ", "IV = ", "PLAINTEXT = ", "CIPHERTEXT = " };
 
-char *test_path = "..\\testvals\\fax\\";
+char *test_path = "../testvals/fax/";
 char *hxx = "0123456789abcdef";
 
 int to_hex(int ch)
@@ -98,7 +98,7 @@ int find_string(const char *s1, const char s2[])
     return -1;
 }
 
-enum line_type find_line(FILE *inf, char str[], char **p)
+line_type find_line(char str[], char **p)
 {   int i;
 
     for(i = 0 ; i < sizeof(hdr_str) / sizeof(hdr_str[0]) ; ++i) 
@@ -240,10 +240,13 @@ void run_aes_avs_test(mode mm, type tt)
         strcat(path, klen_str[i]);
         strcat(path, ".fax");
         if(!(f = fopen(path, "r")))
-            return EXIT_FAILURE;
+        {
+            printf("\nUnable to open %s for reading", path);
+            return;
+        }
         while(get_line(f, inbuf) == EXIT_SUCCESS)
         {
-            if((ty = find_line(f, inbuf, &p)) != L_bad)
+            if((ty = find_line(inbuf, &p)) != L_bad)
                 switch(ty)
                 {
                 case L_count:

--- a/aesgav.c
+++ b/aesgav.c
@@ -45,7 +45,7 @@ Issue Date: 20/12/2007
 // test vector sequences, this code implements one additional (all zero)
 // test vector as the first vector in each set (test 0).
 
-#if defined( DLL_IMPORT ) && defined( DYNAMIC_LINK )
+#if defined( _MSC_VER )
 #include <windows.h>
 #endif
 
@@ -447,7 +447,7 @@ void do_tests(int do_cmp, int ttype[3], f_ectx alg[1], const unsigned long blen,
     int        i;
     FILE       *outf;
 
-    printf("\nGenerate%s tests for aes (AES_BLOCK_SIZE = %i, key size = %lu)\n",
+    printf("\nGenerate%s tests for aes (AES_BLOCK_SIZE = %li, key size = %lu)\n",
             (do_cmp ? " and verify" : ""), 8 * blen, 8 * klen);
 
     for(i = 0; i < 8; ++i)  // for each type of test /k /x /e /c (2 tests each)

--- a/aesrav.c
+++ b/aesrav.c
@@ -38,9 +38,12 @@ Issue Date: 20/12/2007
 // code implements one additional (all zero) test vector as the first
 // vector in each set (test 0).
 
-#if defined( DUAL_CORE ) || defined( DLL_IMPORT ) && defined( DYNAMIC_LINK )
+#if defined( _MSC_VER )
 #  define WINDOWS_LEAN_AND_MEAN
 #  include <windows.h>
+#  define ALIGNED __declspec(align(16))
+#else
+#  define ALIGNED __attribute__ ((aligned(16)))
 #endif
 
 #if defined( __cplusplus )
@@ -96,12 +99,12 @@ void set_dec_key(f_dctx algd[1], unsigned char key[], unsigned long klen)
 void ref_test(const char *in_file, unsigned int it_cnt, enum test_type t_type, f_ectx alge[1],
                                         f_dctx algd[1], unsigned long blen, unsigned long klen)
 {   unsigned long        i, test_cnt, cnt, e_cnt, fe_cnt;
-    __declspec(align(16)) unsigned char key[32], pt[32], iv[32], ect[32], act[64];
+    ALIGNED unsigned char key[32], pt[32], iv[32], ect[32], act[64];
     char                str[128];
     enum line_type      ty;
     FILE                *inf;
 
-    if(fopen_s(&inf, in_file, "r"))      // reference test vector file
+    if(!(inf = fopen(in_file, "r")))     // reference test vector file
     {
         printf("Cannot find test vector file (%s)\n", in_file); return;
     }
@@ -262,7 +265,7 @@ void ref_test(const char *in_file, unsigned int it_cnt, enum test_type t_type, f
     fclose(inf);
 
     if(e_cnt > 0)
-        printf("%i ERRORS during test (first on test %i)\n", e_cnt, fe_cnt);
+        printf("%li ERRORS during test (first on test %li)\n", e_cnt, fe_cnt);
     else
         printf("all tests correct\n");
 }

--- a/aestst.c
+++ b/aestst.c
@@ -47,7 +47,9 @@
 
 #include <stdio.h>
 #include <memory.h>
-#include <windows.h>
+#if defined( _MSC_VER )
+#  include <windows.h>
+#endif
 #include <string.h>
 
 #ifdef AES_CPP
@@ -62,11 +64,6 @@
 fn_ptrs fn;
 #endif
 
-void out_state(long s0, long s1, long s2, long s3)
-{
-    printf("\n%08x%08x508x%08x", s0, s1, s2, s3);
-}
-
 void oblk(char m[], unsigned char v[], unsigned long n)
 {   unsigned long i;
     
@@ -76,7 +73,7 @@ void oblk(char m[], unsigned char v[], unsigned long n)
         printf("%02x", v[i]);
 }
 
-void message(const char *s)   { printf(s); }
+void message(const char *s)   { puts(s); }
 
 unsigned char pih[32] = // hex digits of pi
 {

--- a/aestst.h
+++ b/aestst.h
@@ -28,10 +28,10 @@ Issue Date: 20/12/2007
 
 #define DYNAMIC_LINK
 
-#define abs_path    ".\\"
-#define rel_path    "..\\"
-#define ref_path    "testvals\\"                    // path for test vector files
-#define out_path    "outvals\\"                     // path for output files
+#define abs_path    "./"
+#define rel_path    "../"
+#define ref_path    "testvals/"                    // path for test vector files
+#define out_path    "outvals/"                     // path for output files
 #if 0
 #  define ar_path   abs_path
 #else

--- a/modetest.c
+++ b/modetest.c
@@ -20,8 +20,8 @@ Issue Date: 20/12/2007
 
 #define DUAL_CORE
 
-#if defined( DUAL_CORE ) || defined( DLL_IMPORT ) && defined( DYNAMIC_LINK )
-#include <windows.h>
+#if defined( _MSC_VER )
+#  include <windows.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
I've used the AES code without issue for some time, so I figured that it was time to validate its correctness on Linux.  I went through the test programs one by one, fixing the minor issues I came across (mostly incorrect inclusion of Windows headers and Windows path names).  Everything works except modetest, which compiles fine but segfaults in the aes_ni code.  CLion indicates that there are some issues in the source code but I haven't tracked down whether these are real and exactly why this is happening yet.