### PR TITLE
Fix for modetest crash on non-Windows platforms

### DIFF
--- a/aesaux.c
+++ b/aesaux.c
@@ -190,13 +190,13 @@ int block_cmp(const unsigned char l[], const unsigned char r[], const unsigned l
     return EXIT_SUCCESS;
 }
 
-unsigned long rand32(void)
-{   static unsigned long   r4,r_cnt = (unsigned long)-1, w = 521288629, z = 362436069;
+uint32_t rand32(void)
+{   static uint32_t r4, w = 521288629, z = 362436069;
 
     z = 36969 * (z & 65535) + (z >> 16);
     w = 18000 * (w & 65535) + (w >> 16);
 
-    r_cnt = 0; r4 = (z << 16) + w; return r4;
+    r4 = (z << 16) + w; return r4;
 }
 
 unsigned char rand8(void)
@@ -207,7 +207,7 @@ unsigned char rand8(void)
         r4 = rand32(); r_cnt = 0;
     }
 
-    return (char)(r4 >> (8 * r_cnt++));
+    return (unsigned char)(r4 >> (8 * r_cnt++));
 }
 
 // fill a block with random characters

--- a/aesaux.h
+++ b/aesaux.h
@@ -26,6 +26,7 @@ Issue Date: 25/09/2018
 #include <ctype.h>
 
 #include "aestst.h"
+#include "brg_types.h"
 
 #if defined(__cplusplus)
 extern "C"
@@ -58,7 +59,7 @@ void block_reverse(unsigned char l[], const unsigned long len);
 void block_copy(unsigned char l[], const unsigned char r[], const unsigned long len);
 void block_xor(unsigned char l[], const unsigned char r[], const unsigned long len);
 int block_cmp(const unsigned char l[], const unsigned char r[], const unsigned long len);
-unsigned long rand32(void);
+uint32_t rand32(void);
 unsigned char rand8(void);
 void block_rndfill(unsigned char l[], unsigned long len);
 void put_dec(char *s, unsigned long val);

--- a/aesgav.c
+++ b/aesgav.c
@@ -465,6 +465,8 @@ void do_tests(int do_cmp, int ttype[3], f_ectx alg[1], const unsigned long blen,
 
                 if(do_cmp)  // compare it with reference if required
                     comp_vecs(name2, name1);
+            } else {
+                printf("ERROR: failed to open %s for writing\n", name1);
             }
        }
 }

--- a/modetest.c
+++ b/modetest.c
@@ -1304,7 +1304,7 @@ int main(void)
             memcpy(buf2, buf1, BUFLEN);
             memcpy(buf3, buf1, BUFLEN);
 
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len = (unsigned int)(0.5 * BUFLEN * (1.0 + td));
             len = AES_BLOCK_SIZE * (len / AES_BLOCK_SIZE);
 
@@ -1349,7 +1349,7 @@ int main(void)
             memcpy(buf2, buf1, BUFLEN);
             memcpy(buf3, buf1, BUFLEN);
 
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len = (unsigned int)(0.5 * BUFLEN * (1.0 + td));
             len = AES_BLOCK_SIZE * (len / AES_BLOCK_SIZE);
 
@@ -1412,9 +1412,9 @@ int main(void)
 
             f_info(ecx1) = 0;
             f_mode_reset(ecx2);
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len = (unsigned int)(0.5 * BUFLEN * (1.0 + td));
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len2 = (unsigned int)(td * len);
 #ifdef WHOLE_BLOCKS
             len = AES_BLOCK_SIZE * (len / AES_BLOCK_SIZE);
@@ -1435,7 +1435,7 @@ int main(void)
             f_info(ecx1) = 0;
             f_mode_reset(ecx2);
             CFBdec(buf2, len, iv2, ecx1);
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len2 = (unsigned int)(td * len);
 #ifdef WHOLE_BLOCKS
             len2 = AES_BLOCK_SIZE * (len2 / AES_BLOCK_SIZE);
@@ -1489,9 +1489,9 @@ int main(void)
 
             f_info(ecx1) = 0;
             f_mode_reset(ecx2);
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len = (unsigned int)(0.5 * BUFLEN * (1.0 + td));
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len2 = (unsigned int)(td * len);
 #ifdef WHOLE_BLOCKS
             len = AES_BLOCK_SIZE * (len / AES_BLOCK_SIZE);
@@ -1512,7 +1512,7 @@ int main(void)
             f_info(ecx1) = 0;
             f_mode_reset(ecx2);
             OFBdec(buf2, len, iv2, ecx1);
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len2 = (unsigned int)(td * len);
 #ifdef WHOLE_BLOCKS
             len2 = AES_BLOCK_SIZE * (len2 / AES_BLOCK_SIZE);
@@ -1566,9 +1566,9 @@ int main(void)
 
             f_info(ecx1) = 0;
             f_mode_reset(ecx2);
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len = (unsigned int)(0.5 * BUFLEN * (1.0 + td));
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len2 = (unsigned int)(td * len);
 #ifdef WHOLE_BLOCKS
             len = AES_BLOCK_SIZE * (len / AES_BLOCK_SIZE);
@@ -1588,7 +1588,7 @@ int main(void)
 
             f_info(ecx1) = 0;
             f_mode_reset(ecx2);
-            td = rand32() / (65536.0 * 65536.0);
+            td = rand32() / ((double)UINT32_MAX);
             len2 = (unsigned int)(td * len);
             CTRcry(buf2, len, iv2, ctr_inc, ecx1);
 #ifdef WHOLE_BLOCKS

--- a/modetest.c
+++ b/modetest.c
@@ -22,6 +22,9 @@ Issue Date: 20/12/2007
 
 #if defined( _MSC_VER ) && (defined( DUAL_CORE ) || defined( DLL_IMPORT ) && defined( DLL_DYNAMIC_LOAD ))
 #include <windows.h>
+#elif defined(__GNUC__)
+#  define _GNU_SOURCE
+#  include <sched.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -1266,6 +1269,13 @@ int main(void)
     else
     {
         printf("Couldn't get Process Affinity Mask\n\n"); return -1;
+    }
+#elif defined( DUAL_CORE ) && defined( __GNUC__ )
+    cpu_set_t cpu_set;
+    CPU_ZERO(&cpu_set);
+    CPU_SET(0, &cpu_set);
+    if(sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set) == -1){
+        perror("Unable to set CPU affinity mask"); return -1;
     }
 #endif
 


### PR DESCRIPTION
Looking at the modetest program state in a debugger, I noticed that at the time of the crash the ```len``` variable seemed very high to me (observed values in the hundreds of millions).  This length is based on a pseudo-random value, ```td```, which seems like it should be set to a double between [0..1) but was much higher.  It turns out that the ```rand32``` subroutine currently returns an ```unsigned long```, which is always 32 bits on Windows but is generally 64 bits when compiled with Clang or GCC.  Changing it to return a fixed-width type resolved the crash and the ```modetest``` program appears to work correctly now.

I added some error reporting in ```aesgav``` to make it clear when the program is failing and copied the processor affinity code from ```astmr``` as well.