### PR TITLE
Add helper macros to the keying subroutines for use by language bindings

### DIFF
--- a/aes.h
+++ b/aes.h
@@ -79,6 +79,13 @@ typedef union
     uint8_t b[4];
 } aes_inf;
 
+/* Macros for detecting whether a given context was initialized for  */
+/* use with encryption or decryption code. These should only be used */
+/* by e.g. language bindings which lose type information when the    */
+/* context pointer is passed to the calling language's runtime.      */
+#define IS_ENCRYPTION_CTX(cx) (((cx)->inf.b[2] & (uint8_t)0x01) == 1)
+#define IS_DECRYPTION_CTX(cx) (((cx)->inf.b[2] & (uint8_t)0x01) == 0)
+
 #ifdef _MSC_VER
 #  pragma warning( disable : 4324 )
 #endif

--- a/aeskey.c
+++ b/aeskey.c
@@ -37,6 +37,13 @@ extern "C"
 {
 #endif
 
+/* Use the low bit in the context's inf.b[2] as a flag to
+   indicate whether a context was initialized for encryption
+   or decryption.
+*/
+#define MARK_AS_ENCRYPTION_CTX(cx) (cx)->inf.b[2] |= (uint8_t)0x01
+#define MARK_AS_DECRYPTION_CTX(cx) (cx)->inf.b[2] &= (uint8_t)0xfe
+
 /* Initialise the key schedule from the user supplied key. The key
    length can be specified in bytes, with legal values of 16, 24
    and 32, or in bits, with legal values of 128, 192 and 256. These
@@ -107,6 +114,7 @@ AES_RETURN aes_xi(encrypt_key128)(const unsigned char *key, aes_encrypt_ctx cx[1
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+    MARK_AS_ENCRYPTION_CTX(cx);
     return EXIT_SUCCESS;
 }
 
@@ -156,6 +164,7 @@ AES_RETURN aes_xi(encrypt_key192)(const unsigned char *key, aes_encrypt_ctx cx[1
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+    MARK_AS_ENCRYPTION_CTX(cx);
     return EXIT_SUCCESS;
 }
 
@@ -208,6 +217,7 @@ AES_RETURN aes_xi(encrypt_key256)(const unsigned char *key, aes_encrypt_ctx cx[1
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+    MARK_AS_ENCRYPTION_CTX(cx);
     return EXIT_SUCCESS;
 }
 
@@ -335,6 +345,7 @@ AES_RETURN aes_xi(decrypt_key128)(const unsigned char *key, aes_decrypt_ctx cx[1
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+    MARK_AS_DECRYPTION_CTX(cx);
     return EXIT_SUCCESS;
 }
 
@@ -420,6 +431,7 @@ AES_RETURN aes_xi(decrypt_key192)(const unsigned char *key, aes_decrypt_ctx cx[1
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+    MARK_AS_DECRYPTION_CTX(cx);
     return EXIT_SUCCESS;
 }
 
@@ -516,6 +528,7 @@ AES_RETURN aes_xi(decrypt_key256)(const unsigned char *key, aes_decrypt_ctx cx[1
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+    MARK_AS_DECRYPTION_CTX(cx);
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
The macros added here do two things:

1) In ```aeskey.c```, set the low bit of ```(cx)->inf.b[2]``` to either 1 (for encryption) or 0 (for decryption) when new contexts are initialized.
2) In ```aes.h```, add accessors which can be used to determine whether a given context was initialized for encryption or decryption.

Normally this kind of type checking would be done at compile time.  However, when writing language bindings this type information is effectively lost at the time the context pointer is passed into the other language's runtime (presumably by being cast to a ```void *``` or similar).  This information needs to be preserved somehow so that the language bindings can validate whether the context being passed back and forth is valid for a particular use case.