### PR TITLE
Fix warnings with gcc -Wall -Wsign-compare

### DIFF
--- a/aescrypt.c
+++ b/aescrypt.c
@@ -135,7 +135,7 @@ AES_RETURN aes_xi(encrypt)(const unsigned char *in, unsigned char *out, const ae
 #else
 
 #if (ENC_UNROLL == PARTIAL)
-    {   uint32_t    rnd;
+    {   int         rnd;
         for(rnd = 0; rnd < (cx->inf.b[0] >> 5) - 1; ++rnd)
         {
             kp += N_COLS;
@@ -146,7 +146,7 @@ AES_RETURN aes_xi(encrypt)(const unsigned char *in, unsigned char *out, const ae
         kp += N_COLS;
         round(fwd_rnd,  b1, b0, kp);
 #else
-    {   uint32_t    rnd;
+    {   int         rnd;
         for(rnd = 0; rnd < (cx->inf.b[0] >> 4) - 1; ++rnd)
         {
             kp += N_COLS;
@@ -266,7 +266,7 @@ AES_RETURN aes_xi(decrypt)(const unsigned char *in, unsigned char *out, const ae
 #else
 
 #if (DEC_UNROLL == PARTIAL)
-    {   uint32_t    rnd;
+    {   int         rnd;
         for(rnd = 0; rnd < (cx->inf.b[0] >> 5) - 1; ++rnd)
         {
             kp = rnd_key(1);
@@ -277,7 +277,7 @@ AES_RETURN aes_xi(decrypt)(const unsigned char *in, unsigned char *out, const ae
         kp = rnd_key(1);
         round(inv_rnd, b1, b0, kp);
 #else
-    {   uint32_t    rnd;
+    {   int         rnd;
         for(rnd = 0; rnd < (cx->inf.b[0] >> 4) - 1; ++rnd)
         {
             kp = rnd_key(1);

--- a/aeskey.c
+++ b/aeskey.c
@@ -404,8 +404,10 @@ AES_RETURN aes_xi(decrypt_key192)(const unsigned char *key, aes_decrypt_ctx cx[1
     cx->ks[v(48,(3))] = ss[3] = word_in(key, 3);
 
 #ifdef DEC_KS_UNROLL
-    cx->ks[v(48,(4))] = ff(ss[4] = word_in(key, 4));
-    cx->ks[v(48,(5))] = ff(ss[5] = word_in(key, 5));
+    ss[4] = word_in(key, 4);
+    ss[5] = word_in(key, 5);
+    cx->ks[v(48,(4))] = ff(ss[4]);
+    cx->ks[v(48,(5))] = ff(ss[5]);
     kdf6(cx->ks, 0); kd6(cx->ks, 1);
     kd6(cx->ks, 2);  kd6(cx->ks, 3);
     kd6(cx->ks, 4);  kd6(cx->ks, 5);
@@ -497,10 +499,14 @@ AES_RETURN aes_xi(decrypt_key256)(const unsigned char *key, aes_decrypt_ctx cx[1
     cx->ks[v(56,(3))] = ss[3] = word_in(key, 3);
 
 #ifdef DEC_KS_UNROLL
-    cx->ks[v(56,(4))] = ff(ss[4] = word_in(key, 4));
-    cx->ks[v(56,(5))] = ff(ss[5] = word_in(key, 5));
-    cx->ks[v(56,(6))] = ff(ss[6] = word_in(key, 6));
-    cx->ks[v(56,(7))] = ff(ss[7] = word_in(key, 7));
+    ss[4] = word_in(key, 4);
+    ss[5] = word_in(key, 5);
+    ss[6] = word_in(key, 6);
+    ss[7] = word_in(key, 7);
+    cx->ks[v(56,(4))] = ff(ss[4]);
+    cx->ks[v(56,(5))] = ff(ss[5]);
+    cx->ks[v(56,(6))] = ff(ss[6]);
+    cx->ks[v(56,(7))] = ff(ss[7]);
     kdf8(cx->ks, 0); kd8(cx->ks, 1);
     kd8(cx->ks, 2);  kd8(cx->ks, 3);
     kd8(cx->ks, 4);  kd8(cx->ks, 5);


### PR DESCRIPTION
The aeskey.c warnings are described in issue #53.  Although ss[n] is assigned to the same value each time after macro expansion, my reading of C99 section 6.5 is that it is nonconformant to assign to a single lvalue multiple times without a sequence point in between, even if the values assigned to it are identical.

The sign-comparison warnings in aescrypt.c only appear when ENC_UNROLL or DEC_UNROLL is not set to the default (FULL), and only with -Wsign-compare.  I don't think there is anything strictly wrong with a signed/unsigned comparison in these places since the loop bound expression is never expected to be negative, but using a loop counter of the same type as the bound is trivial.
