### PR TITLE
Add explicit Fallthrough comments to case statements

### DIFF
--- a/aescrypt.c
+++ b/aescrypt.c
@@ -115,10 +115,12 @@ AES_RETURN aes_xi(encrypt)(const unsigned char *in, unsigned char *out, const ae
         round(fwd_rnd,  b1, b0, kp + 1 * N_COLS);
         round(fwd_rnd,  b0, b1, kp + 2 * N_COLS);
         kp += 2 * N_COLS;
+    /* FALLTHRU */
     case 12 * AES_BLOCK_SIZE:
         round(fwd_rnd,  b1, b0, kp + 1 * N_COLS);
         round(fwd_rnd,  b0, b1, kp + 2 * N_COLS);
         kp += 2 * N_COLS;
+    /* FALLTHRU */
     case 10 * AES_BLOCK_SIZE:
         round(fwd_rnd,  b1, b0, kp + 1 * N_COLS);
         round(fwd_rnd,  b0, b1, kp + 2 * N_COLS);
@@ -247,9 +249,11 @@ AES_RETURN aes_xi(decrypt)(const unsigned char *in, unsigned char *out, const ae
     case 14 * AES_BLOCK_SIZE:
         round(inv_rnd,  b1, b0, rnd_key(-13));
         round(inv_rnd,  b0, b1, rnd_key(-12));
+    /* FALLTHRU */ 
     case 12 * AES_BLOCK_SIZE:
         round(inv_rnd,  b1, b0, rnd_key(-11));
         round(inv_rnd,  b0, b1, rnd_key(-10));
+    /* FALLTHRU */
     case 10 * AES_BLOCK_SIZE:
         round(inv_rnd,  b1, b0, rnd_key(-9));
         round(inv_rnd,  b0, b1, rnd_key(-8));


### PR DESCRIPTION
Fix implicit-fallthrough warning in GCC > 7