### PR TITLE
Visual Studio 2022 ARM64 support

### DIFF
--- a/aes_ni.c
+++ b/aes_ni.c
@@ -26,7 +26,9 @@ Issue Date: 03/08/2018
 #if defined(_MSC_VER)
 
 #include <intrin.h>
+#ifndef _ARM64EC_
 #pragma intrinsic(__cpuid)
+#endif // !_ARM64EC_
 #define INLINE  __inline
 
 INLINE int has_aes_ni(void)

--- a/aesopt.h
+++ b/aesopt.h
@@ -172,7 +172,7 @@ Issue Date: 20/12/2007
 /* AESNI is supported by all Windows x64 compilers, but for Linux/GCC
    we have to test for SSE 2, SSE 3, and AES to before enabling it; */
 #if !defined( INTEL_AES_POSSIBLE )
-#  if defined( _WIN64 ) && defined( _MSC_VER ) \
+#  if defined( _WIN64 ) && defined( _MSC_VER ) && defined( _M_AMD64 ) \
    || defined( __GNUC__ ) && defined( __x86_64__ ) && \
 	  defined( __SSE2__ ) && defined( __SSE3__ ) && \
 	  defined( __AES__ )

--- a/brg_endian.h
+++ b/brg_endian.h
@@ -119,6 +119,7 @@ Issue Date: 10/09/2018
       defined( __i386__ )  || defined( _M_I86 )  || defined( _M_IX86 )    || \
       defined( __OS2__ )   || defined( sun386 )  || defined( __TURBOC__ ) || \
       defined( vax )       || defined( vms )     || defined( VMS )        || \
+      defined( _M_ARM64 )  || defined ( _M_ARM ) || \
       defined( __VMS )     || defined( _M_X64 )
 #  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
 


### PR DESCRIPTION
This permits the compilation, without warnings, of the library with Visual Studio 2022 when targeting ARM64 and ARM64EC platforms.