### PR TITLE
Fix different 'const' qualifier

### DIFF
--- a/aes_modes.c
+++ b/aes_modes.c
@@ -156,14 +156,13 @@ AES_RETURN aes_ecb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
 
             while(nb)
             {
                 int m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb);
 
-                ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
-                op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
+                const uint8_t *ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
+                uint8_t *op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
 
                 if(ip != ibuf)
                     memcpy(buf, ibuf, m * AES_BLOCK_SIZE);
@@ -218,14 +217,13 @@ AES_RETURN aes_ecb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
 
             while(nb)
             {
                 int m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb);
 
-                ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
-                op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
+                const uint8_t *ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
+                uint8_t *op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
 
                 if(ip != ibuf)
                     memcpy(buf, ibuf, m * AES_BLOCK_SIZE);
@@ -287,14 +285,13 @@ AES_RETURN aes_cbc_encrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
 
             while(nb)
             {
                 int m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb);
 
-                ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
-                op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
+                const uint8_t *ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
+                uint8_t *op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
 
                 if(ip != ibuf)
                     memcpy(buf, ibuf, m * AES_BLOCK_SIZE);
@@ -385,14 +382,13 @@ AES_RETURN aes_cbc_decrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
 
             while(nb)
             {
                 int m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb);
 
-                ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
-                op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
+                const uint8_t *ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
+                uint8_t *op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
 
                 if(ip != ibuf)
                     memcpy(buf, ibuf, m * AES_BLOCK_SIZE);
@@ -474,8 +470,7 @@ AES_RETURN aes_cfb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
 #if defined( USE_VIA_ACE_IF_PRESENT )
 
         if(ctx->inf.b[1] == 0xff)
-        {   int m;
-            uint8_t *ksp = (uint8_t*)(ctx->ks), *ivp = iv;
+        {   uint8_t *ksp = (uint8_t*)(ctx->ks), *ivp = iv;
             aligned_auto(uint8_t, liv, AES_BLOCK_SIZE, 16);
             via_cwd(cwd, hybrid, enc, 2 * ctx->inf.b[0] - 192);
 
@@ -497,14 +492,13 @@ AES_RETURN aes_cfb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
             }
             else    /* input, output or both are unaligned  */
             {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-                uint8_t *ip, *op;
 
                 while(nb)
                 {
-                    m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb), nb -= m;
+                    int m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb);
 
-                    ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
-                    op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
+                    const uint8_t *ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
+                    uint8_t *op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
 
                     if(ip != ibuf)
                         memcpy(buf, ibuf, m * AES_BLOCK_SIZE);
@@ -517,6 +511,7 @@ AES_RETURN aes_cfb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
                     ibuf += m * AES_BLOCK_SIZE;
                     obuf += m * AES_BLOCK_SIZE;
                     cnt  += m * AES_BLOCK_SIZE;
+                    nb -= m;
                 }
             }
 
@@ -602,8 +597,7 @@ AES_RETURN aes_cfb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
 #if defined( USE_VIA_ACE_IF_PRESENT )
 
         if(ctx->inf.b[1] == 0xff)
-        {   int m;
-            uint8_t *ksp = (uint8_t*)(ctx->ks), *ivp = iv;
+        {   uint8_t *ksp = (uint8_t*)(ctx->ks), *ivp = iv;
             aligned_auto(uint8_t, liv, AES_BLOCK_SIZE, 16);
             via_cwd(cwd, hybrid, dec, 2 * ctx->inf.b[0] - 192);
 
@@ -625,14 +619,13 @@ AES_RETURN aes_cfb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
             }
             else    /* input, output or both are unaligned  */
             {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-                uint8_t *ip, *op;
 
                 while(nb)
                 {
-                    m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb), nb -= m;
+                    int m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb);
 
-                    ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
-                    op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
+                    const uint8_t *ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
+                    uint8_t *op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
 
                     if(ip != ibuf)  /* input buffer is not aligned */
                         memcpy(buf, ibuf, m * AES_BLOCK_SIZE);
@@ -645,6 +638,7 @@ AES_RETURN aes_cfb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
                     ibuf += m * AES_BLOCK_SIZE;
                     obuf += m * AES_BLOCK_SIZE;
                     cnt  += m * AES_BLOCK_SIZE;
+                    nb -= m;
                 }
             }
 
@@ -740,8 +734,7 @@ AES_RETURN aes_ofb_crypt(const unsigned char *ibuf, unsigned char *obuf,
 #if defined( USE_VIA_ACE_IF_PRESENT )
 
         if(ctx->inf.b[1] == 0xff)
-        {   int m;
-            uint8_t *ksp = (uint8_t*)(ctx->ks), *ivp = iv;
+        {   uint8_t *ksp = (uint8_t*)(ctx->ks), *ivp = iv;
             aligned_auto(uint8_t, liv, AES_BLOCK_SIZE, 16);
             via_cwd(cwd, hybrid, enc, 2 * ctx->inf.b[0] - 192);
 
@@ -767,10 +760,10 @@ AES_RETURN aes_ofb_crypt(const unsigned char *ibuf, unsigned char *obuf,
 
                 while(nb)
                 {
-                    m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb), nb -= m;
+                    int m = (nb > BFR_BLOCKS ? BFR_BLOCKS : nb);
 
-                    ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
-                    op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
+                    const uint8_t *ip = (ALIGN_OFFSET( ibuf, 16 ) ? buf : ibuf);
+                    uint8_t *op = (ALIGN_OFFSET( obuf, 16 ) ? buf : obuf);
 
                     if(ip != ibuf)
                         memcpy(buf, ibuf, m * AES_BLOCK_SIZE);
@@ -783,6 +776,7 @@ AES_RETURN aes_ofb_crypt(const unsigned char *ibuf, unsigned char *obuf,
                     ibuf += m * AES_BLOCK_SIZE;
                     obuf += m * AES_BLOCK_SIZE;
                     cnt  += m * AES_BLOCK_SIZE;
+                    nb -= m;
                 }
             }
 


### PR DESCRIPTION
Also reduce the scope of impacted variables (code style) and use the same loop style everywhere.

Resolves https://github.com/BrianGladman/aes/issues/69 , we are confident that there should be no change in the resulting behavior but it has not been tested on a Via machine :(, this patch is mainly for clearing out the current warnings we get, in order to see any new and relevant future warnings in our software.